### PR TITLE
Only apply the sort if the sort order has changed.

### DIFF
--- a/tabs_extra.py
+++ b/tabs_extra.py
@@ -1073,8 +1073,9 @@ class TabsExtraSortCommand(sublime_plugin.WindowCommand):
         sorted_views = sorted(view_data, key=itemgetter(*indexes))
         if self.reverse:
             sorted_views = sorted_views[::-1]
-        for index in range(0, len(sorted_views)):
-            self.window.set_view_index(sorted_views[index][-1], self.group, index)
+        if sorted_views != view_data:
+            for index in range(0, len(sorted_views)):
+                self.window.set_view_index(sorted_views[index][-1], self.group, index)
 
     def get_sort_module(self, module_name):
         """Import the sort_by module."""


### PR DESCRIPTION
Stops the tab bar jumping around when you hit save multiple times with
`sort_on_load_save` enabled
(https://github.com/facelessuser/TabsExtra/issues/35).

This fixes the issue for me, but I’m a Python n00b, so feel free to reject it if it doesn’t make sense or might introduce other problems.