### PR TITLE
Show confirmation dialog when moving/renaming to a file that exists

### DIFF
--- a/tabs_extra.py
+++ b/tabs_extra.py
@@ -741,6 +741,9 @@ class TabsExtraRenameCommand(sublime_plugin.WindowCommand):
 
         new = os.path.join(branch, leaf)
 
+        if os.path.exists(new) and not sublime.ok_cancel_dialog("Overwrite %s?" % new, "Replace"):
+            return
+
         try:
             os.rename(old, new)
 
@@ -789,6 +792,9 @@ class TabsExtraMoveCommand(sublime_plugin.WindowCommand):
 
     def on_done(self, old, new):
         """Handle the moving when user is done with the input panel."""
+
+        if os.path.exists(new) and not sublime.ok_cancel_dialog("Overwrite %s?" % new, "Replace"):
+            return
 
         try:
             directory = os.path.dirname(new)


### PR DESCRIPTION
Pretty self-explanatory; **tabs_extra_move** and **tabs_extra_rename** commands don't check if the new filepath already exists, so I inadvertently overwritten files a few times 😅

The dialog text matches the one in the **tabs_extra_duplicate** command.